### PR TITLE
Skip TitechPortalMockServerTests when CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Build
-        run: swift build
       - name: Run tests
         run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -34,3 +34,10 @@ let package = Package(
             ]),
     ]
 )
+
+import Foundation
+if ProcessInfo.processInfo.environment["CI"] == "true" {
+    for target in package.targets {
+        target.swiftSettings = [.define("CI")]
+    }
+}

--- a/Tests/TitechPortalKitTests/TitechPortalMockServerTests.swift
+++ b/Tests/TitechPortalKitTests/TitechPortalMockServerTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 @testable import TitechPortalKit
 
+#if !CI
+
 final class TitechPortalMockServerTests: XCTestCase {
     func testMockServerLogin() async throws {
         TitechPortal.changeToMockServer()
@@ -94,3 +96,5 @@ final class TitechPortalMockServerTests: XCTestCase {
         )
     }
 }
+
+#endif


### PR DESCRIPTION
### 概要

TitechPortalMockServerTestsはLinuxでうまくCookieがいかないのとMockServerに依存するテストをいつも動かす必要はないのでCI環境ではスキップさせます